### PR TITLE
Add initial contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to the Kalispell Software Crafters GitHub Pages Website
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to the Kalispell Software Crafters GitHub Pages website, which is hosted in the [kalispell-software-crafters.github.io](https://github.com/kalispell-software-crafters/kalispell-software-crafters.github.io) repo on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Pull Requests](#pull-requests)
+
+[Acknowledgements](#acknowledgements)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Kalispell Software Crafters Code of Conduct](https://github.com/kalispell-software-crafters/code-of-conduct). By participating, you are expected to uphold this code.
+
+## What should I know before I get started?
+
+This website is a community driven project for the [Kalispell Software Crafters Meetup group](https://www.meetup.com/Kalispell-Software-Crafters/). In time the site will provide information about our meetup group and scheduled events. This repo also provides newcomers and experienced programmers alike a place to collaborate and learn together. 
+
+For now we are focused on keeping the website simple using the fundamental building blocks of the web. Namely HTML, CSS, and JavaScript. With time that will grow as our needs change and the complexity grows.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for the site. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### Before Submitting A Bug Report
+
+* **Perform a [cursory search](https://github.com/kalispell-software-crafters/kalispell-software-crafters.github.io/issues)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include links to files, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) on Linux.
+
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for the site, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
+
+#### Before Submitting An Enhancement Suggestion
+
+* **Perform a [cursory search](https://github.com/kalispell-software-crafters/kalispell-software-crafters.github.io/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of website which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) on Linux.
+* **Explain why this enhancement would be useful** to most users.
+
+### Your First Code Contribution
+
+Unsure where to begin contributing? Check out the [issues](https://github.com/kalispell-software-crafters/kalispell-software-crafters.github.io/issues) tab for any outstanding issues that interest you. This is a small project so there may not be any. If you have suggested changes create an enhancement issue as outlined above.
+
+#### Local development
+
+[Fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) the project on GitHub and [clone](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository) the repository locally to your computer. Be sure [npm](https://www.npmjs.com/get-npm) is installed and run an ```npm install``` in the project directory. Then you can run ```npm start``` to run the project locally and open it in a browser.
+
+### Pull Requests
+
+The process described here has several goals:
+
+- Maintain the website's quality
+- Fix problems that are important to users
+- Engage the community in working toward the best possible website
+- Enable a sustainable system for the website's maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Associate related issues
+2. Assign reviewers
+3. Provide screenshots (if applicable) of any UI updates
+4. Explain your changes
+5. Add or update unit tests (if applicable)
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+
+## Acknowledgements
+
+This contributing guide is based off the Atom guide found here: https://github.com/atom/atom/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This PR adds an initial contributing guide to our repo. I followed the Atom guide as an example (https://github.com/atom/atom/blob/master/CONTRIBUTING.md).

Sample from VS Code:
![image](https://user-images.githubusercontent.com/7952281/96376557-f15c4c80-113c-11eb-8c22-de3aea8958d3.png)

Closes #42 