### PR TITLE
Fix profile image urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
-import skylerImgUrl from './imgs/skyler.jpg';
-import travisImgUrl from './imgs/travis.jpg';
+const SKYLER_PHOTO_URL = new URL('./imgs/skyler.jpg', import.meta.url).href;
+const TRAVIS_PHOTO_URL = new URL('./imgs/travis.jpg', import.meta.url).href;
 
 // handles keypresses for accessibility
-
 function handleClick(e) {
 	if (e.type === 'keypress') {
 		const code = e.keyCode;
@@ -38,7 +37,6 @@ const orgPhoto = document.getElementById('about__photo');
 
 const orgProfiles = document.querySelectorAll('.profile');
 
-// Add event listener to profiles
 for (let i = 0; i < orgProfiles.length; i++) {
 	orgProfiles[i].addEventListener('click', selectProfile);
 	orgProfiles[i].addEventListener('keypress', e => {
@@ -48,19 +46,16 @@ for (let i = 0; i < orgProfiles.length; i++) {
 	});
 }
 
-// Function to select organizer profile -- updates from organizers data object
 function selectProfile(e) {
 	const currentProfileId = e.currentTarget.id;
 	const selectedOrganizer = organizers[currentProfileId];
 
 	if (selectedOrganizer) {
-		// Remove default highlighted profile
 		currentProfile.classList.remove('profile--selected');
-		// Update current profile to be highlighted
+
 		currentProfile = document.getElementById(`${currentProfileId}`);
 		currentProfile.classList.add('profile--selected');
 
-		// Update about section content
 		orgName.textContent = selectedOrganizer.name;
 		orgAbout.textContent = selectedOrganizer.about;
 		orgPhoto.src = selectedOrganizer.profilePhoto;
@@ -72,11 +67,11 @@ const organizers = {
 	Travis: {
 		name: 'Travis Craft',
 		about: "I'm a Flathead native and remote software engineer. I want to connect with others to talk about software development and engineering. I first learned about software craftsmanship in the Fall of 2017 which led me to create this group. I've learned a lot along the way!",
-		profilePhoto: travisImgUrl
+		profilePhoto: TRAVIS_PHOTO_URL
 	},
 	Skyler: {
 		name: 'Skyler Bexten',
 		about: 'Flathead native with computer science degree from UM. Fell in love with programming in a Java course. Likes JavaScript, test-driven development and plays with Haskell on the side. Reads too many books on the history of computer science and too much manga.',
-		profilePhoto: skylerImgUrl
+		profilePhoto: SKYLER_PHOTO_URL
 	}
 };


### PR DESCRIPTION
Organizer profile images were broken since Parcel adjusts static content names. With the updates the file names will be consistent when they're replaced during the build. I also removed some comments.

Fixes issue https://github.com/kalispell-software-crafters/kalispell-software-crafters.github.io/issues/115